### PR TITLE
Comment by les on setting-up-raspberry-pi-for-kiosk-mode

### DIFF
--- a/_data/comments/setting-up-raspberry-pi-for-kiosk-mode/70ee13e4.yml
+++ b/_data/comments/setting-up-raspberry-pi-for-kiosk-mode/70ee13e4.yml
@@ -1,0 +1,18 @@
+id: 70ee13e4
+date: 2018-11-24T14:47:27.1226759Z
+name: les
+avatar: https://avatars.io/twitter//medium
+message: >-
+  So. I like this tutorial, however, there is no longer an lxsession directory in the user home directory. The only directories in .config are chromium, lxpanel, and lxterminal.
+
+
+
+  The is an lxsession directory in /etc/xdg/. Should I be editing this file? It seems that wouldn't be true since it appears to be a global setting.
+
+
+
+  Please advise.
+
+
+
+  Thank you


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter//medium" width="64" height="64" />

So. I like this tutorial, however, there is no longer an lxsession directory in the user home directory. The only directories in .config are chromium, lxpanel, and lxterminal.

The is an lxsession directory in /etc/xdg/. Should I be editing this file? It seems that wouldn't be true since it appears to be a global setting.

Please advise.

Thank you