### PR TITLE
Comment by Mike Jolley on setting-up-raspberry-pi-for-kiosk-mode

### DIFF
--- a/_data/comments/setting-up-raspberry-pi-for-kiosk-mode/e37480ce.yml
+++ b/_data/comments/setting-up-raspberry-pi-for-kiosk-mode/e37480ce.yml
@@ -1,0 +1,21 @@
+id: e37480ce
+date: 2018-11-26T22:08:20.1054804Z
+name: Mike Jolley
+avatar: https://avatars.io/twitter/@michaeljolley/medium
+message: >+
+  @les, just to clarify, the .config/lxsession/LDXE-pi directory is in the home/pi directory.  So run:
+
+
+
+  ```
+
+  cd /home/pi/.config/lxsession/LXDE-pi
+
+  ```
+
+
+
+  I'll update the post to clear up any confusion.  Thanks for the feedback & question!
+
+
+

--- a/_posts/2018/2018-11-13-setting-up-raspberry-pi-for-kiosk-mode.md
+++ b/_posts/2018/2018-11-13-setting-up-raspberry-pi-for-kiosk-mode.md
@@ -40,7 +40,7 @@ We're going to launch Chromium after boot-up with the following settings:
 
 To do this we'll be editing the **autostart** file in **.config/lxsession/LXDE-pi/**.  So navigate to it with:
 
-<pre class="language-bash"><code>cd .config/lxsession/LXDE-pi/</code></pre>
+<pre class="language-bash"><code>cd /home/pi/.config/lxsession/LXDE-pi/</code></pre>
 
 Then edit it with nano like so:
 


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter/@michaeljolley/medium" width="64" height="64" />

@les, just to clarify, the .config/lxsession/LDXE-pi directory is in the home/pi directory.  So run:

```
cd /home/pi/.config/lxsession/LXDE-pi
```

I'll update the post to clear up any confusion.  Thanks for the feedback & question!

