### PR TITLE
Comment by Paul on setting-up-raspberry-pi-for-kiosk-mode

### DIFF
--- a/_data/comments/setting-up-raspberry-pi-for-kiosk-mode/4e402f38.yml
+++ b/_data/comments/setting-up-raspberry-pi-for-kiosk-mode/4e402f38.yml
@@ -1,0 +1,7 @@
+id: 4e402f38
+date: 2018-12-04T08:46:14.8391539Z
+name: Paul
+avatar: https://avatars.io/twitter//medium
+message: >+
+  I presume  this setup is done with "Raspbian Stretch Lite" installed?
+


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter//medium" width="64" height="64" />

I presume  this setup is done with "Raspbian Stretch Lite" installed?
