### PR TITLE
Comment by Mike Jolley on setting-up-raspberry-pi-for-kiosk-mode

### DIFF
--- a/_data/comments/setting-up-raspberry-pi-for-kiosk-mode/66a98a0a.yml
+++ b/_data/comments/setting-up-raspberry-pi-for-kiosk-mode/66a98a0a.yml
@@ -1,0 +1,5 @@
+id: 66a98a0a
+date: 2018-12-04T16:07:36.8870971Z
+name: Mike Jolley
+avatar: https://avatars.io/twitter/@michaeljolley/medium
+message: "@Paul, it was actually done with Raspbian Stretch, but I don't see why it wouldn't work just as well with Raspbian Stretch Lite."


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter/@michaeljolley/medium" width="64" height="64" />

@Paul, it was actually done with Raspbian Stretch, but I don't see why it wouldn't work just as well with Raspbian Stretch Lite.