### PR TITLE
Comment by Maks on release-notes-with-github-appveyor-octopus-deploy

### DIFF
--- a/_data/comments/release-notes-with-github-appveyor-octopus-deploy/5450467c.yml
+++ b/_data/comments/release-notes-with-github-appveyor-octopus-deploy/5450467c.yml
@@ -1,0 +1,5 @@
+id: 5450467c
+date: 2020-01-04T14:09:20.6871017Z
+name: Maks
+avatar: https://avatars.io/twitter//medium
+message: "Hello MICHAEL,\r\nIt is very usefully article. Thanks a lot!\r\nBut this solution can have one big minus, since Github API cannot work with more than 250 commits and you must use git CLI to resolve it. \r\nDo you use git CLI in octopus to get release notes?"


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter//medium" width="64" height="64" />

Hello MICHAEL,
It is very usefully article. Thanks a lot!
But this solution can have one big minus, since Github API cannot work with more than 250 commits and you must use git CLI to resolve it. 
Do you use git CLI in octopus to get release notes?