### PR TITLE
Comment by Michael Jolley on release-notes-with-github-appveyor-octopus-deploy

### DIFF
--- a/_data/comments/release-notes-with-github-appveyor-octopus-deploy/00d3f367.yml
+++ b/_data/comments/release-notes-with-github-appveyor-octopus-deploy/00d3f367.yml
@@ -1,0 +1,10 @@
+id: 00d3f367
+date: 2020-01-05T03:17:18.4561661Z
+name: Michael Jolley
+avatar: https://avatars.io/twitter/baldbeardbuild/medium
+message: >-
+  That's a good point Maks.  I've never experience that issue because I previously worked in a very agile organization where we generated builds nearly daily with a team of 20 people at most.  Those 20 people were actually spread across several projects so we may only have 3-5 people committing to any one repo per day which limited the number of commits to well under 250.
+
+
+
+  But certainly, if you're in a less agile or waterfall based development cycle, you'll probably want to look at a different method or, as you mentioned, utilize the git CLI directly to access the commits.


### PR DESCRIPTION
avatar: <img src="https://avatars.io/twitter/baldbeardbuild/medium" width="64" height="64" />

That's a good point Maks.  I've never experience that issue because I previously worked in a very agile organization where we generated builds nearly daily with a team of 20 people at most.  Those 20 people were actually spread across several projects so we may only have 3-5 people committing to any one repo per day which limited the number of commits to well under 250.

But certainly, if you're in a less agile or waterfall based development cycle, you'll probably want to look at a different method or, as you mentioned, utilize the git CLI directly to access the commits.